### PR TITLE
Process links inside <div> tags and after <br>s, but not inside links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 **.gem
+.ruby-version

--- a/lib/html/pipeline/youtube/youtube_filter.rb
+++ b/lib/html/pipeline/youtube/youtube_filter.rb
@@ -11,9 +11,10 @@ module HTML
         #   :video_wmode - string, sets iframe's wmode option
         #   :video_autoplay - boolean, whether video should autoplay
         #   :video_hide_related - boolean, whether shows related videos
-        regex = /(\s(https?:\/\/)|^(https?:\/\/))(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
+        regex = /(\s(https?:\/\/)|^(https?:\/\/)|>(https?:\/\/))(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
         @text.gsub(regex) do
-          youtube_id = $6
+          youtube_id = $7
+          close_tag = $1[0] if $1[0] == ">"
           width = context[:video_width] || 420
           height = context[:video_height] || 315
           frameborder = context[:video_frameborder] || 0
@@ -27,7 +28,7 @@ module HTML
           params << "rel=0" if hide_related
           src += "?#{params.join '&'}" unless params.empty?
 
-          %{<div class="video youtube"><iframe width="#{width}" height="#{height}" src="#{src}" frameborder="#{frameborder}" allowfullscreen></iframe></div>}
+          %{#{close_tag}<div class="video youtube"><iframe width="#{width}" height="#{height}" src="#{src}" frameborder="#{frameborder}" allowfullscreen></iframe></div>}
         end
       end
     end

--- a/lib/html/pipeline/youtube/youtube_filter.rb
+++ b/lib/html/pipeline/youtube/youtube_filter.rb
@@ -11,10 +11,10 @@ module HTML
         #   :video_wmode - string, sets iframe's wmode option
         #   :video_autoplay - boolean, whether video should autoplay
         #   :video_hide_related - boolean, whether shows related videos
-        regex = /(\s(https?:\/\/)|^(https?:\/\/)|>(https?:\/\/))(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
+        regex = /(\s|^|<div>|<br>)(https?:\/\/)(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
         @text.gsub(regex) do
-          youtube_id = $7
-          close_tag = $1[0] if $1[0] == ">"
+          youtube_id = $5
+          close_tag = $1 if ["<br>", "<div>"].include? $1
           width = context[:video_width] || 420
           height = context[:video_height] || 315
           frameborder = context[:video_frameborder] || 0

--- a/spec/html/pipeline/youtube_filter_spec.rb
+++ b/spec/html/pipeline/youtube_filter_spec.rb
@@ -19,11 +19,18 @@ describe HTML::Pipeline::YoutubeFilter do
 
       expect(subject.to_html(hyper_link)).to eq(hyper_link)
     end
-    it "does affect links in html element" do
+    it "does affect links in a div" do
       hyper_link = %(<div>https://www.youtube.com/watch?v=Kg4aWWIsszw</div>)
 
       expect(subject.to_html(hyper_link)).to eq(
         %(<div><div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div></div>)
+      )
+    end
+    it "does affect links after a br" do
+      hyper_link = %(<br>https://www.youtube.com/watch?v=Kg4aWWIsszw)
+
+      expect(subject.to_html(hyper_link)).to eq(
+        %(<br><div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div>)
       )
     end
   end

--- a/spec/html/pipeline/youtube_filter_spec.rb
+++ b/spec/html/pipeline/youtube_filter_spec.rb
@@ -9,15 +9,22 @@ describe HTML::Pipeline::YoutubeFilter do
   end
 
   context "With other filter's result" do
-    it "doesn't effect links in markdown" do
+    it "doesn't affect links in markdown" do
       markdown_link = "[Video](https://www.youtube.com/watch?v=Kg4aWWIsszw)"
 
       expect(subject.to_html(markdown_link)).to eq(markdown_link)
     end
-    it "doesn't effect links in html tag" do
+    it "doesn't affect links in html tag" do
       hyper_link = %(<a href="https://www.youtube.com/watch?v=Kg4aWWIsszw">Video</a>)
 
       expect(subject.to_html(hyper_link)).to eq(hyper_link)
+    end
+    it "does affect links in html element" do
+      hyper_link = %(<div>https://www.youtube.com/watch?v=Kg4aWWIsszw</div>)
+
+      expect(subject.to_html(hyper_link)).to eq(
+        %(<div><div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div></div>)
+      )
     end
   end
 


### PR DESCRIPTION
My use case is using html-pipeline-youtube inside the trix WYSIWYG editor. Trix does a nice job of minimally marking up content but any raw link will follow a br tag (if it's on a newline) or be enclosed in a div.

I adjusted the regex to account for those two possibilities and still create the embedded iframe, but still not touch youtube links encoded within other tags or within a link.

Not sure that fits your use case but thought I'd pass it along if interested.
