### PR TITLE
A few bugfixes

### DIFF
--- a/lib/html/pipeline/youtube/youtube_filter.rb
+++ b/lib/html/pipeline/youtube/youtube_filter.rb
@@ -11,10 +11,9 @@ module HTML
         #   :video_wmode - string, sets iframe's wmode option
         #   :video_autoplay - boolean, whether video should autoplay
         #   :video_hide_related - boolean, whether shows related videos
-        regex = /(\s|^|<div>|<br>)(https?:\/\/)(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
+        regex = /(?<=^|\s|<div>|<br>)https?:\/\/(?:www.)?(?:youtube\.com\/(?:embed\/|watch\?(?:feature=player_embedded&)?v=)|youtu\.be\/)([A-Za-z0-9_-]*)[&?\w-]*/
         @text.gsub(regex) do
-          youtube_id = $5
-          close_tag = $1 if ["<br>", "<div>"].include? $1
+          youtube_id = $1
           width = context[:video_width] || 420
           height = context[:video_height] || 315
           frameborder = context[:video_frameborder] || 0
@@ -28,7 +27,8 @@ module HTML
           params << "rel=0" if hide_related
           src += "?#{params.join '&'}" unless params.empty?
 
-          %{#{close_tag}<div class="video youtube"><iframe width="#{width}" height="#{height}" src="#{src}" frameborder="#{frameborder}" allowfullscreen></iframe></div>}
+          # Prefix with two "\n" for compatibility with markup such as Markdown:
+          %{\n\n<div class="video youtube"><iframe width="#{width}" height="#{height}" src="#{src}" frameborder="#{frameborder}" allowfullscreen></iframe></div>}
         end
       end
     end

--- a/spec/html/pipeline/youtube_filter_spec.rb
+++ b/spec/html/pipeline/youtube_filter_spec.rb
@@ -23,14 +23,26 @@ describe HTML::Pipeline::YoutubeFilter do
       hyper_link = %(<div>https://www.youtube.com/watch?v=Kg4aWWIsszw</div>)
 
       expect(subject.to_html(hyper_link)).to eq(
-        %(<div><div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div></div>)
+        %(<div>\n\n<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div></div>)
       )
     end
     it "does affect links after a br" do
       hyper_link = %(<br>https://www.youtube.com/watch?v=Kg4aWWIsszw)
 
       expect(subject.to_html(hyper_link)).to eq(
-        %(<br><div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div>)
+        %(<br>\n\n<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div>)
+      )
+    end
+    it "does not consume whitespace" do
+      source = 'Check out https://www.youtube.com/watch?v=Kg4aWWIsszw now'
+      expect(subject.to_html(source)).to eq(
+        %(Check out \n\n<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div> now)
+      )
+    end
+    it "supports /embed URLs" do
+      source = 'https://www.youtube.com/embed/Kg4aWWIsszw'
+      expect(subject.to_html(source)).to eq(
+        %(\n\n<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div>)
       )
     end
   end
@@ -38,7 +50,7 @@ describe HTML::Pipeline::YoutubeFilter do
   context "With no options" do
     it "generates iframe with default setting" do
       expect(subject.to_html(youtube_url)).to eq(
-        %(<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div>)
+        %(\n\n<div class="video youtube"><iframe width="420" height="315" src="//www.youtube.com/embed/Kg4aWWIsszw" frameborder="0" allowfullscreen></iframe></div>)
       )
     end
   end
@@ -55,7 +67,7 @@ describe HTML::Pipeline::YoutubeFilter do
       )
 
       expect(result).to eq(
-        %(<div class="video youtube"><iframe width="500" height="100" src="//www.youtube.com/embed/Kg4aWWIsszw?autoplay=1&rel=0" frameborder="5" allowfullscreen></iframe></div>)
+        %(\n\n<div class="video youtube"><iframe width="500" height="100" src="//www.youtube.com/embed/Kg4aWWIsszw?autoplay=1&rel=0" frameborder="5" allowfullscreen></iframe></div>)
       )
     end
   end


### PR DESCRIPTION
1. Support /embed/ URLs
2. Insert two newlines before the output.
   This does not affect the HTML result but makes the result compatible with markup engines such as Markdown, which usually require an empty line before the start of a block element.